### PR TITLE
Prep for 0.1.0 Release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test
-  # - sbt ++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues
+  - sbt ++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues
   - sbt ++$TRAVIS_SCALA_VERSION docs/makeMicrosite
 
 after_success:

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val `cats-time` = project.in(file("."))
 lazy val core = crossProject(JSPlatform, JVMPlatform)
     .crossType(CrossType.Pure)
     .in(file("modules/core"))
-    .settings(commonSettings, releaseSettings)
+    .settings(commonSettings, releaseSettings, mimaSettings)
     .settings(
       name := "cats-time"
     ).jsSettings(

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.4-SNAPSHOT"
+version in ThisBuild := "0.1.0-SNAPSHOT"


### PR DESCRIPTION
Bumps version so release goes out as 0.1.0.

This has seen use happily by many folks, and I think its time to add a layer of stability.