### PR TITLE
Documentation for New Instances, MonthDay to all

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -183,7 +183,7 @@ lazy val mimaSettings = {
     }
   }
   // Safety Net For Exclusions
-  lazy val excludedVersions: Set[String] = Set()
+  lazy val excludedVersions: Set[String] = Set("0.1.0")
 
   // Safety Net for Inclusions
   lazy val extraVersions: Set[String] = Set()

--- a/modules/core/src/main/scala/io/chrisdavenport/cats/time/instances/all.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/cats/time/instances/all.scala
@@ -6,6 +6,7 @@ trait all
   with localdate
   with localdatetime
   with localtime
+  with monthday
   with offsetdatetime
   with offsettime
   with period

--- a/modules/docs/src/main/tut/index.md
+++ b/modules/docs/src/main/tut/index.md
@@ -43,11 +43,15 @@ LocalDateTime.now.show
 
 LocalTime.now.show
 
+MonthDay.now.show
+
 OffsetDateTime.now.show
 
 OffsetTime.now.show
 
 Period.ofWeeks(6).show
+
+Year.now.show
 
 YearMonth.now.show
 


### PR DESCRIPTION
Well I botched that release by missing that. Going to release `0.1.1` with these changes.

Please do not use `0.1.0`.