### PR TITLE
Add Eq[ZoneId], Hash[ZoneId]

### DIFF
--- a/modules/core/src/main/scala/io/chrisdavenport/cats/time/instances/zoneid.scala
+++ b/modules/core/src/main/scala/io/chrisdavenport/cats/time/instances/zoneid.scala
@@ -5,7 +5,9 @@ import java.time.ZoneId
 
 trait zoneid {
   implicit final val zoneidInstances = 
-    new Show[ZoneId]{
+    new Show[ZoneId] with Eq[ZoneId] with Hash[ZoneId]{
+      override def eqv(x: ZoneId, y: ZoneId): Boolean = x.equals(y)
+      override def hash(x: ZoneId): Int = x.hashCode
       override def show(x: ZoneId): String = x.getId
     }
 }

--- a/modules/core/src/test/scala/io/chrisdavenport/cats/time/instances/ZoneIdTests.scala
+++ b/modules/core/src/test/scala/io/chrisdavenport/cats/time/instances/ZoneIdTests.scala
@@ -2,13 +2,13 @@ package io.chrisdavenport.cats.time.instances
 
 
 import cats.tests.CatsSuite
-// import cats.kernel.laws.discipline.HashTests
-// import cats.kernel.laws.discipline.OrderTests
-// import TimeArbitraries._
-// import java.time.ZoneId
-// import io.chrisdavenport.cats.time.instances.hashWithOrder._
+import cats.kernel.laws.discipline.HashTests
+import cats.kernel.laws.discipline.EqTests
+import TimeArbitraries._
+import java.time.ZoneId
+import io.chrisdavenport.cats.time.instances.zoneid._
 
 class ZoneIdTests extends CatsSuite {
-  // checkAll("ZoneId", HashTests[ZoneId].hash)
-  // checkAll("ZoneId", OrderTests[ZoneId].order)
+  checkAll("ZoneId", EqTests[ZoneId].eqv)
+  checkAll("ZoneId", HashTests[ZoneId].hash)
 }


### PR DESCRIPTION
These were missing for some reason.

The choice is to use the standard `.equals` and `.hashCode`, rather than normalizing `ZoneId`s via `.normalized`.